### PR TITLE
Disable eslint react proptype check rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
     "react/react-in-jsx-scope": 2,
     "react/jsx-quotes": 0,
     "react/no-multi-comp": [2, { "ignoreStateless": true }],
+    "react/prop-types": 0,
     "jsx-quotes": 2,
     "block-scoped-var": 0,
     "padded-blocks": 0,


### PR DESCRIPTION
If we need type check, I prefer using [Flow](https://flowtype.org/).
So eslint react prop type check is unnecessary.